### PR TITLE
Add akbild wien

### DIFF
--- a/cmd/generaterss/main.go
+++ b/cmd/generaterss/main.go
@@ -13,8 +13,9 @@ import (
 
 const TU_WIEN int = 1098
 const UNI_PASSAU int = 196
+const AKBILD_WIEN int = 1957
 
-var Canteens []int = []int{TU_WIEN, UNI_PASSAU}
+var Canteens []int = []int{TU_WIEN, UNI_PASSAU, AKBILD_WIEN}
 
 func main() {
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
This pull request updates the `cmd/generaterss/main.go` file to include a new canteen in the list of supported canteens.

### Changes:
* Added a constant `AKBILD_WIEN` with a value of `1957` to represent a new canteen.
* Updated the `Canteens` slice to include the new `AKBILD_WIEN` constant.