### PR TITLE
Add GUID to items based on hashed meal title and date

### DIFF
--- a/openmensarss.go
+++ b/openmensarss.go
@@ -1,6 +1,8 @@
 package openmensarss
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -66,13 +68,13 @@ func generateFeed(canteen *openmensa.Canteen, date time.Time) (*feeds.Feed, erro
 	feed.Items = make([]*feeds.Item, 0, len(menu.Meals))
 
 	for _, meal := range menu.Meals {
-		feed.Add(createFeedItem(meal))
+		feed.Add(createFeedItem(meal, date))
 	}
 
 	return feed, nil
 }
 
-func createFeedItem(meal openmensa.Meal) *feeds.Item {
+func createFeedItem(meal openmensa.Meal, date time.Time) *feeds.Item {
 	prices := []string{}
 
 	var roles = [...]string{"students", "pupils", "employees", "others"}
@@ -93,5 +95,13 @@ func createFeedItem(meal openmensa.Meal) *feeds.Item {
 		Title:       meal.Name,
 		Description: fmt.Sprintf("%v<br />%v %v", meal.Category, priceInfo, allergenInfo),
 		Link:        RSSMetadata.Link,
+		Id:          generateGUID(meal.Name, date),
+		IsPermaLink: "false",
 	}
+}
+
+func generateGUID(title string, date time.Time) string {
+	content := fmt.Sprintf("%s|%s", title, date.Format("2006-01-02"))
+	hash := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(hash[:])
 }


### PR DESCRIPTION
Example item:
```xml
<item>
  <title>Lauchcremesuppe</title>
  <link>https://schicho.github.io/openmensarss/</link>
  <description>Suppe&lt;br /&gt;&lt;i&gt;Students: 0.80&lt;/i&gt;, &lt;i&gt;Employees: 1.00&lt;/i&gt;, &lt;i&gt;Others: 1.50&lt;/i&gt; (mit Antioxidationsmittel, Milch und Milchprodukte, Sellerie, vegetarisch)</description>
  <guid isPermaLink="false">55218ff3aeb351e848b8a30a176109e5f96375e61beace0c0df522cdb6fe188c</guid>
</item>
```
where the `<guid>` element is new.

Without this, some RSS readers will only show one item per page and regard the others as duplicates.
See for example a screenshot of the "NetNewsWire" app below.
<img width="1457" height="1012" alt="image" src="https://github.com/user-attachments/assets/3ca6d4a1-975b-4759-967d-03047a22c4bb" />
